### PR TITLE
Remove padding that breaks alignment

### DIFF
--- a/scss/_c-content.scss
+++ b/scss/_c-content.scss
@@ -104,7 +104,7 @@
 .c-code,
 .c-content code {
   font-size: 85%;
-  padding: 0.3rem;
+  padding: 0;
   border-radius: 0.2rem;
   font-family: Monaco, Menlo, monospace;
   background: #FFF6FF;


### PR DESCRIPTION
There is padding of 0.3rem which breaks formatting. Screenshot at Routify Discord:
https://discord.com/channels/683709869626490889/702185788216967250/806540826108231710