### PR TITLE
Update props example in guide

### DIFF
--- a/src/pages/guide/introduction/props.svelte
+++ b/src/pages/guide/introduction/props.svelte
@@ -16,7 +16,7 @@
     <Code>
         {`
             export let scoped
-            $: {user} = scoped
+            $: ({user} = scoped)
         `}
     </Code>
 


### PR DESCRIPTION
A parse error occurs when trying something like `$: {user} = scoped`. Wrapping it in another block doesn't help but the parentheses get it working. 

After creating this PR due to bumping into this on my own, I now see the old thread linked from within #182. 

Aside: Is this something Svelte should parse? 

resolves: #182