### PR TITLE
docs: Clarify how the script is loaded

### DIFF
--- a/src/pages/guide/installation/install-to-existing-project.svelte
+++ b/src/pages/guide/installation/install-to-existing-project.svelte
@@ -135,7 +135,26 @@
 
 <div class="c-container-vertical c-container-vertical--small">
   <div class="c-content">
-    <h2>6. Enable SPA</h2>
+    <h2>6. Update the script tag</h2>
+    <p>
+      Ensure that your script is loaded with type "module" in your entrypoint HTML file.
+    </p>
+  </div>
+  <div class="card">
+    <Code language="html">
+      {`
+        /* index.html */
+        ...
+        <script type="module" src='/build/main.js'></script>
+        ...
+      `}
+    </Code>
+  </div>
+</div>
+
+<div class="c-container-vertical c-container-vertical--small">
+  <div class="c-content">
+    <h2>7. Enable SPA</h2>
     <p>
       Make sure that your server redirects all 404s to your app's path. Usually
       "/index.html" or just "/".


### PR DESCRIPTION
This commit adds some clarification to the documentation for adding
Routify to an existing project.  When coming from a project built from
the Svelte template, Rollup is configured to output IIFE which works
fine with a normal script tag.  After changing to ESM you need to also
make sure the script is loaded with type "module" otherwise you'll see
errors at runtime around invalid syntax such as:

`Uncaught SyntaxError: Unexpected token 'export'`