### PR TITLE
Invalid JSON format in Page's meta

### DIFF
--- a/src/pages/docs/metadata.svelte
+++ b/src/pages/docs/metadata.svelte
@@ -132,7 +132,7 @@
 
   <Code language="html">
     {`
-      <!-- _outify:option_ tags=['recipes', 'cupcakes'] -->
+      <!-- _outify:option_ tags=["recipes", "cupcakes"] -->
       <!-- _outify:option_ published=true -->
       `}
   </Code>


### PR DESCRIPTION
Fixed the example with page meta, where the format is invalid JSON.